### PR TITLE
Fix: Omit tool_calls from assistant message if empty

### DIFF
--- a/web/src/common/openai.test.ts
+++ b/web/src/common/openai.test.ts
@@ -1,0 +1,81 @@
+// web/src/common/openai.test.ts
+import { OpenAiChannel, MyMessage } from './openai'; // Adjust path as needed
+import { describe, it, expect, beforeEach } from 'vitest';
+
+describe('OpenAiChannel.messages_format', () => {
+  let channel: OpenAiChannel;
+
+  beforeEach(() => {
+    // Minimal options needed for OpenAiChannel instantiation for this test
+    channel = new OpenAiChannel({ apiKey: 'test', baseURL: 'test' });
+  });
+
+  it('should omit tool_calls if content_tool_calls is undefined', async () => {
+    const messages: MyMessage[] = [
+      { role: 'user', content: 'Hello' },
+      { 
+        role: 'assistant', 
+        content: 'Thinking...', 
+        content_tool_calls: undefined 
+      }
+    ];
+    const formattedMessages = await channel.messages_format(messages);
+    const assistantMessage = formattedMessages.find(m => m.role === 'assistant');
+    expect(assistantMessage).toBeDefined();
+    expect(assistantMessage).not.toHaveProperty('tool_calls');
+  });
+
+  it('should omit tool_calls if content_tool_calls is null', async () => {
+    const messages: MyMessage[] = [
+      { role: 'user', content: 'Hello' },
+      { 
+        role: 'assistant', 
+        content: 'Thinking...', 
+        // @ts-ignore // To allow null assignment for testing, if MyMessage['content_tool_calls'] doesn't normally allow null
+        content_tool_calls: null 
+      }
+    ];
+    const formattedMessages = await channel.messages_format(messages);
+    const assistantMessage = formattedMessages.find(m => m.role === 'assistant');
+    expect(assistantMessage).toBeDefined();
+    expect(assistantMessage).not.toHaveProperty('tool_calls');
+  });
+
+  it('should omit tool_calls if content_tool_calls is an empty array', async () => {
+    const messages: MyMessage[] = [
+      { role: 'user', content: 'Hello' },
+      { 
+        role: 'assistant', 
+        content: 'Thinking...', 
+        content_tool_calls: [] 
+      }
+    ];
+    const formattedMessages = await channel.messages_format(messages);
+    const assistantMessage = formattedMessages.find(m => m.role === 'assistant');
+    expect(assistantMessage).toBeDefined();
+    expect(assistantMessage).not.toHaveProperty('tool_calls');
+  });
+
+  // Optional: Add a test case for when content_tool_calls is valid and non-empty
+  it('should include tool_calls if content_tool_calls is valid and non-empty', async () => {
+    const messages: MyMessage[] = [
+      { role: 'user', content: 'Hello' },
+      { 
+        role: 'assistant', 
+        content: 'Thinking...', 
+        content_tool_calls: [{
+          id: 'call_123',
+          type: 'function',
+          function: { name: 'get_weather', arguments: '{"location": "Boston"}' }
+        }]
+      }
+    ];
+    const formattedMessages = await channel.messages_format(messages);
+    const assistantMessage = formattedMessages.find(m => m.role === 'assistant');
+    expect(assistantMessage).toBeDefined();
+    expect(assistantMessage).toHaveProperty('tool_calls');
+    expect(assistantMessage.tool_calls).toHaveLength(1);
+    // @ts-ignore
+    expect(assistantMessage.tool_calls[0].function.name).toBe('get_weather');
+  });
+});

--- a/web/src/common/openai.ts
+++ b/web/src/common/openai.ts
@@ -754,13 +754,18 @@ export class OpenAiChannel {
         ...rest
       } = m;
       if (rest.role == "assistant") {
-        rest.tool_calls = content_tool_calls?.map((x: Tool_Call) => {
-          let { origin_name, restore_name, ...rest } = x;
-          let { argumentsOBJ, ...functionRest } = rest.function;
-          rest.function = functionRest as any;
-          return rest;
-        }) as any;
-        if (rest.tool_calls?.length == 0) {
+        // Check if content_tool_calls is valid and has items before mapping
+        if (content_tool_calls && content_tool_calls.length > 0) {
+          rest.tool_calls = content_tool_calls.map((x: Tool_Call) => {
+            // Using 'restCall' to avoid shadowing the outer 'rest' variable from message destructuring
+            let { origin_name, restore_name, ...restCall } = x; 
+            let { argumentsOBJ, ...functionRest } = restCall.function; // argumentsOBJ is part of x.function
+            restCall.function = functionRest as any;
+            return restCall; // Return the modified 'restCall' object
+          }) as any;
+        } else {
+          // If content_tool_calls is null, undefined, or empty,
+          // ensure tool_calls is not part of the resulting object.
           delete rest.tool_calls;
         }
       }


### PR DESCRIPTION
The OpenAI API expects the `tool_calls` array to have a minimum length of 1 if the property is present in an assistant message. Sending an empty `tool_calls` array results in a 400 error.

This commit fixes the issue by modifying the `messages_format` method in `web/src/common/openai.ts`. The method now checks if `content_tool_calls` (the source array from `MyMessage`) is null, undefined, or empty. If it is, the `tool_calls` property is deleted from the formatted assistant message object before it's sent to the API. This ensures that an empty `tool_calls` array is not transmitted.

A potential variable shadowing issue within the map function was also addressed by renaming an inner variable.

Unit tests have been added in `web/src/common/openai.test.ts` to cover scenarios where `content_tool_calls` is undefined, null, or empty, verifying that `tool_calls` is correctly omitted. A test case for valid `content_tool_calls` is also included.